### PR TITLE
Add missing EqualWeightStrategy and create_strategy to base_strategy

### DIFF
--- a/src/strategies/base_strategy.py
+++ b/src/strategies/base_strategy.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from typing import Any, Dict, Optional
 import pandas as pd
 
+
 @dataclass
 class StrategyResult:
     strategy_name: str
@@ -25,3 +26,26 @@ class BaseStrategy:
 
     def generate_weights(self, data: Dict[str, pd.DataFrame], target_date: Optional[str] = None) -> StrategyResult:
         raise NotImplementedError("generate_weights must be implemented by subclasses")
+
+class EqualWeightStrategy(BaseStrategy):
+    """A strategy class that gives equal weight to all stocks"""
+
+    def generate_weights(self, data: Dict[str, pd.DataFrame], target_date: Optional[str] = None) -> StrategyResult:
+        tickers = data["fundamentals"]["gvkey"].unique()
+        weight = 1.0 / len(tickers)
+        weights_df = pd.DataFrame({
+            "gvkey": tickers,
+            "weight": [weight] * len(tickers)
+        })
+        return StrategyResult(strategy_name=self.config.name, weights=weights_df)
+
+
+def create_strategy(strategy_type, config):
+    strategies = {
+        "equal_weight": EqualWeightStrategy,
+    }
+
+    strategy_class = strategies.get(strategy_type)
+    if strategy_class == None:
+        raise ValueError(f"Unknown strategy type: {strategy_type}")
+    return strategy_class(config)


### PR DESCRIPTION
Related to #80

The web dashboard imports `EqualWeightStrategy` and `create_strategy` from `base_strategy.py`, but neither exists, so the dashboard crashes on load.

Added:
- `EqualWeightStrategy`: extends `BaseStrategy`, splits weights equally across all tickers in the universe.
- `create_strategy(strategy_type, config)`: factory function mapping strategy type strings to their classes.

File changed: `src/strategies/base_strategy.py`