### PR TITLE
Bump streamlit to >=1.54.0 to fix SSRF vulnerability (CVE-2026-33682)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ plotly>=5.15.0
 seaborn>=0.12.0
 
 # Web framework
-streamlit>=1.28.0
+streamlit>=1.54.0
 
 # Financial data sources
 yfinance>=0.2.0


### PR DESCRIPTION
Related to #82

Bumps minimum streamlit from 1.28.0 to 1.54.0 for CVE-2026-33682. Unauthenticated SSRF in ComponentRequestHandler, leaks NTLM creds on Windows through malicious UNC paths.

Windows-only. Linux and macOS aren't affected.

Checked src/web/app.py against the 1.28 to 1.54 changelog. No deprecated API usage, no breaking changes.

File changed: `requirements.txt`